### PR TITLE
Readme update: res.locals.user.allocationJobResponsibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ optional middleware which populates:
 - `res.locals.user.caseLoads` with all case loads the user has access to
 - `res.locals.user.activeCaseLoad` with the active case load of the user
 - `res.locals.user.activeCaseLoadId` with the id of the active case load
+- `res.locals.user.allocationJobResponsibilities` with the job responsibilities for which the user may have prisoners allocated to them, such as `KEY_WORKER` and `PERSONAL_OFFICER` responsibilities
  
 It uses the `sharedData` object if it is present and caches in `req.session` so that any subsequent routes that do not 
 use the component middleware can still use the data. If there is no data in the cache, it will fall back to making a 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ This includes:
 - activeCaseLoad (the active caseload of the user)
 - caseLoads (all caseloads the user has access to)
 - services (information on services the user has access to used for global navigation)
+- allocationJobResponsibilities (the allocation policy codes the user has the associated job responsibility for. Allocation policy codes are: `KEY_WORKER`, meaning the user is a key worker and `PERSONAL_OFFICER`, meaning the user is a personal officer.)
 
 This can be useful e.g. for when your service needs access to activeCaseLoad information to prevent extra calls to the 
 api and takes advantage of the caching that the micro frontend api does.

--- a/README.md
+++ b/README.md
@@ -171,8 +171,7 @@ optional middleware which populates:
 - `res.locals.user.caseLoads` with all case loads the user has access to
 - `res.locals.user.activeCaseLoad` with the active case load of the user
 - `res.locals.user.activeCaseLoadId` with the id of the active case load
-- `res.locals.user.allocationJobResponsibilities` with the job responsibilities for which the user may have prisoners allocated to them, such as `KEY_WORKER` and `PERSONAL_OFFICER` responsibilities
- 
+
 It uses the `sharedData` object if it is present and caches in `req.session` so that any subsequent routes that do not 
 use the component middleware can still use the data. If there is no data in the cache, it will fall back to making a 
 call to Prison API to retrieve the data using the user token.
@@ -187,6 +186,30 @@ Again there are a [number of options](./src/index.ts) available depending on you
 
 This middleware checks the `res.locals.user.authSource` so ensure that any mock auth data used in tests includes 
 `auth_source: 'nomis'` in the response.
+
+### Populating res.locals.user with the shared allocation job responsibilities
+
+This library also provides an optional middleware which populates:
+- `res.locals.user.allocationJobResponsibilities` the allocation policy codes the user has the associated job responsibility for. Allocation policy codes are: `KEY_WORKER`, meaning the user is a key worker and `PERSONAL_OFFICER`, meaning the user is a personal officer.
+
+Similar to shared case load data, it uses the `sharedData` object if it is present and caches in `req.session` so that any subsequent routes that do not
+use the component middleware can still use the data. If there is no data in the cache, it will fall back to making a
+call to Allocations API to retrieve the data using the user token.
+
+To enable this, add the middleware after the component middleware as follows:
+
+```javascript
+app.use(dpsComponents.retrieveAllocationJobResponsibilities({ logger }))
+```
+
+This should go after `dpsComponents.retrieveCaseLoadData` so that `res.locals.user.activeCaseLoadId` will be populated.
+It also requires `ALLOCATIONS_API_URL` to be configured in the environment variables.
+
+Again there are a [number of options](./src/index.ts) available depending on your requirements.
+
+This middleware checks the `res.locals.user.authSource` so ensure that any mock auth data used in tests includes
+`auth_source: 'nomis'` in the response. It also checks the `res.locals.user.activeCaseLoadId`, which is required for retrieving allocation job responsibilities.
+
 
 ### Note
 

--- a/src/@types/express/index.d.ts
+++ b/src/@types/express/index.d.ts
@@ -1,6 +1,7 @@
 import CaseLoad from '../../types/CaseLoad'
 import HeaderFooterSharedData from '../../types/HeaderFooterSharedData'
 import { HmppsUser } from '../../types/HmppsUser'
+import { AllocationJobResponsibility } from '../../types/AllocationJobResponsibility'
 
 // eslint-disable-next-line import/prefer-default-export
 export declare global {
@@ -9,6 +10,7 @@ export declare global {
       caseLoads?: CaseLoad[]
       activeCaseLoad?: CaseLoad
       activeCaseLoadId?: string
+      allocationJobResponsibilities?: AllocationJobResponsibility[]
     }
 
     interface FeComponents {

--- a/src/allocationService.test.ts
+++ b/src/allocationService.test.ts
@@ -3,8 +3,10 @@ import { PrisonUser } from './types/HmppsUser'
 import retrieveAllocationJobResponsibilities from './allocationService'
 import allocationsApiClient from './data/allocationsApi/allocationsApiClient'
 import { AllocationJobResponsibility } from './types/AllocationJobResponsibility'
+import config from './config'
 
 jest.mock('./data/allocationsApi/allocationsApiClient')
+jest.mock('./config')
 
 describe('retrieveCaseLoadData', () => {
   let req: Request
@@ -17,8 +19,15 @@ describe('retrieveCaseLoadData', () => {
 
   const allocationJobResponsibilities: AllocationJobResponsibility[] = ['KEY_WORKER']
 
+  const configMock = config as jest.Mocked<typeof config>
+
   beforeEach(() => {
     jest.resetAllMocks()
+    configMock.apis = {
+      feComponents: { url: 'url' },
+      prisonApi: { url: 'url' },
+      allocationsApi: { url: 'url' },
+    }
   })
 
   it('Should use shared data from feComponents and refresh the cache', async () => {

--- a/src/allocationService.test.ts
+++ b/src/allocationService.test.ts
@@ -1,0 +1,109 @@
+import { Request, Response } from 'express'
+import { PrisonUser } from './types/HmppsUser'
+import retrieveAllocationJobResponsibilities from './allocationService'
+import allocationsApiClient from './data/allocationsApi/allocationsApiClient'
+import { AllocationJobResponsibility } from './types/AllocationJobResponsibility'
+
+jest.mock('./data/allocationsApi/allocationsApiClient')
+
+describe('retrieveCaseLoadData', () => {
+  let req: Request
+  let res: Response
+  const next = jest.fn()
+
+  const prisonUser = { token: 'token', authSource: 'nomis' } as PrisonUser
+
+  const allocationsApiClientMock = allocationsApiClient as jest.Mocked<typeof allocationsApiClient>
+
+  const allocationJobResponsibilities: AllocationJobResponsibility[] = ['KEY_WORKER']
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('Should use shared data from feComponents and refresh the cache', async () => {
+    req = { session: {} } as unknown as Request
+    res = {
+      locals: {
+        user: prisonUser,
+        feComponents: {
+          sharedData: {
+            allocationJobResponsibilities,
+          },
+        },
+      },
+    } as unknown as Response
+
+    await retrieveAllocationJobResponsibilities({})(req, res, next)
+
+    const localsUser = res.locals.user as PrisonUser
+    expect(localsUser.allocationJobResponsibilities).toEqual(allocationJobResponsibilities)
+    expect(req.session.allocationJobResponsibilities).toEqual(allocationJobResponsibilities)
+    expect(allocationsApiClient.getStaffAllocationPolicies).not.toHaveBeenCalled()
+  })
+
+  it('Should use cached data where feComponents.sharedData is not available', async () => {
+    req = { session: { allocationJobResponsibilities } } as unknown as Request
+    res = {
+      locals: {
+        user: prisonUser,
+      },
+    } as unknown as Response
+
+    await retrieveAllocationJobResponsibilities({})(req, res, next)
+
+    const localsUser = res.locals.user as PrisonUser
+    expect(localsUser.allocationJobResponsibilities).toEqual(allocationJobResponsibilities)
+    expect(allocationsApiClient.getStaffAllocationPolicies).not.toHaveBeenCalled()
+  })
+
+  it('Should call Allocations API when there is no cached data available', async () => {
+    req = { session: {} } as unknown as Request
+    res = { locals: { user: prisonUser } } as unknown as Response
+
+    allocationsApiClientMock.getStaffAllocationPolicies.mockResolvedValue({ policies: allocationJobResponsibilities })
+
+    await retrieveAllocationJobResponsibilities({})(req, res, next)
+
+    const localsUser = res.locals.user as PrisonUser
+    expect(localsUser.allocationJobResponsibilities).toEqual(allocationJobResponsibilities)
+    expect(req.session.allocationJobResponsibilities).toEqual(allocationJobResponsibilities)
+
+    expect(allocationsApiClient.getStaffAllocationPolicies).toHaveBeenCalledWith(
+      prisonUser,
+      expect.anything(),
+      expect.anything(),
+    )
+  })
+
+  it('Should propagate error from Allocations API client', async () => {
+    req = { session: {} } as unknown as Request
+    res = { locals: { user: prisonUser } } as unknown as Response
+
+    const error = new Error('Error')
+
+    allocationsApiClientMock.getStaffAllocationPolicies.mockRejectedValue(error)
+
+    await retrieveAllocationJobResponsibilities({})(req, res, next)
+
+    expect(next).toHaveBeenCalledWith(error)
+  })
+
+  it('Should do nothing if user is not a NOMIS user', async () => {
+    req = { session: {} } as unknown as Request
+    res = { locals: { user: { authSource: 'external', token: 'TOKEN' } } } as unknown as Response
+
+    await retrieveAllocationJobResponsibilities({})(req, res, next)
+
+    expect(allocationsApiClient.getStaffAllocationPolicies).not.toHaveBeenCalled()
+  })
+
+  it('Should throw an error if user session is not available', async () => {
+    req = {} as Request
+    res = { locals: { user: prisonUser } } as unknown as Response
+
+    await expect(retrieveAllocationJobResponsibilities({})(req, res, next)).rejects.toThrow(
+      'User session required in order to cache allocation job responsibilities',
+    )
+  })
+})

--- a/src/allocationService.test.ts
+++ b/src/allocationService.test.ts
@@ -115,4 +115,15 @@ describe('retrieveCaseLoadData', () => {
       'User session required in order to cache allocation job responsibilities',
     )
   })
+
+  it('Should throw an error if Allocations API URL is not defined', async () => {
+    configMock.apis = {
+      ...configMock.apis,
+      allocationsApi: { url: undefined },
+    }
+
+    expect(retrieveAllocationJobResponsibilities).toThrow(
+      'Environment variable ALLOCATIONS_API_URL must be defined for this middleware to work correctly',
+    )
+  })
 })

--- a/src/allocationService.ts
+++ b/src/allocationService.ts
@@ -1,6 +1,7 @@
 import { type RequestHandler } from 'express'
 import CaseLoadOptions from './types/CaseLoadOptions'
 import allocationsApiClient from './data/allocationsApi/allocationsApiClient'
+import config from './config'
 
 const defaultOptions: CaseLoadOptions = {
   logger: console,
@@ -12,6 +13,9 @@ export default function retrieveAllocationJobResponsibilities(options?: CaseLoad
     ...defaultOptions,
     ...options,
   }
+
+  if (!config.apis.allocationsApi.url)
+    throw new Error('Environment variable ALLOCATIONS_API_URL must be defined for this middleware to work correctly')
 
   return async (req, res, next) => {
     if (!req.session) throw new Error('User session required in order to cache allocation job responsibilities')

--- a/src/allocationService.ts
+++ b/src/allocationService.ts
@@ -1,0 +1,53 @@
+import { type RequestHandler } from 'express'
+import CaseLoadOptions from './types/CaseLoadOptions'
+import allocationsApiClient from './data/allocationsApi/allocationsApiClient'
+
+const defaultOptions: CaseLoadOptions = {
+  logger: console,
+  timeoutOptions: { response: 2500, deadline: 2500 },
+}
+
+export default function retrieveAllocationJobResponsibilities(options?: CaseLoadOptions): RequestHandler {
+  const { logger, timeoutOptions } = {
+    ...defaultOptions,
+    ...options,
+  }
+
+  return async (req, res, next) => {
+    if (!req.session) throw new Error('User session required in order to cache allocation job responsibilities')
+    if (!res.locals.user.token)
+      throw new Error(
+        'Caseload details needs to be populated before retrieving allocation job responsibilities. Please run retrieveCaseLoadData before retrieveAllocationJobResponsibilities.',
+      )
+
+    if (res.locals.user && res.locals.user.authSource === 'nomis') {
+      try {
+        // Update cache with values from res.feComponents.sharedData if present
+        if (res.locals.feComponents && res.locals.feComponents.sharedData) {
+          req.session.allocationJobResponsibilities = res.locals.feComponents.sharedData.allocationJobResponsibilities
+        }
+
+        // If cache is empty, fetch data from Prison API
+        if (!req.session.allocationJobResponsibilities) {
+          logger.info(
+            `Falling back to Allocations API to retrieve job responsibilities for: ${res.locals.user.username}`,
+          )
+          const allocationPolicies = await allocationsApiClient.getStaffAllocationPolicies(
+            res.locals.user,
+            timeoutOptions,
+            logger,
+          )
+          req.session.allocationJobResponsibilities = allocationPolicies.policies
+        }
+
+        // Populate res.locals.user with values from cache
+        res.locals.user.allocationJobResponsibilities = req.session.allocationJobResponsibilities
+      } catch (error) {
+        logger.error(error, `Failed to retrieve allocation job responsibilities for: ${res.locals.user.username}`)
+        return next(error)
+      }
+    }
+
+    return next()
+  }
+}

--- a/src/caseLoadService.test.ts
+++ b/src/caseLoadService.test.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express'
 import { PrisonUser } from './types/HmppsUser'
 import retrieveCaseLoadData from './caseLoadService'
 import prisonApiClient from './data/prisonApi/prisonApiClient'
+import config from './config'
 
 jest.mock('./data/prisonApi/prisonApiClient')
 
@@ -35,8 +36,15 @@ describe('retrieveCaseLoadData', () => {
 
   const prisonApiClientMock = prisonApiClient as jest.Mocked<typeof prisonApiClient>
 
+  const configMock = config as jest.Mocked<typeof config>
+
   beforeEach(() => {
     jest.resetAllMocks()
+    configMock.apis = {
+      feComponents: { url: 'url' },
+      prisonApi: { url: 'url' },
+      allocationsApi: { url: 'url' },
+    }
   })
 
   it('Should use shared data from feComponents and refresh the cache', async () => {

--- a/src/caseLoadService.test.ts
+++ b/src/caseLoadService.test.ts
@@ -174,4 +174,15 @@ describe('retrieveCaseLoadData', () => {
       'User session required in order to cache case loads',
     )
   })
+
+  it('Should throw an error if Prison API URL is not defined', async () => {
+    configMock.apis = {
+      ...configMock.apis,
+      prisonApi: { url: undefined },
+    }
+
+    expect(retrieveCaseLoadData).toThrow(
+      'Environment variable PRISON_API_URL must be defined for this middleware to work correctly',
+    )
+  })
 })

--- a/src/caseLoadService.ts
+++ b/src/caseLoadService.ts
@@ -2,6 +2,7 @@ import { type RequestHandler } from 'express'
 import CaseLoadOptions from './types/CaseLoadOptions'
 import CaseLoad from './types/CaseLoad'
 import prisonApiClient from './data/prisonApi/prisonApiClient'
+import config from './config'
 
 const defaultOptions: CaseLoadOptions = {
   logger: console,
@@ -13,6 +14,9 @@ export default function retrieveCaseLoadData(caseLoadOptions?: CaseLoadOptions):
     ...defaultOptions,
     ...caseLoadOptions,
   }
+
+  if (!config.apis.prisonApi.url)
+    throw new Error('Environment variable PRISON_API_URL must be defined for this middleware to work correctly')
 
   return async (req, res, next) => {
     if (!req.session) throw new Error('User session required in order to cache case loads')

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,5 +21,8 @@ export default {
     prisonApi: {
       url: get('PRISON_API_URL', null),
     },
+    allocationsApi: {
+      url: get('ALLOCATIONS_API_URL', null),
+    },
   },
 }

--- a/src/data/allocationsApi/allocationsApiClient.ts
+++ b/src/data/allocationsApi/allocationsApiClient.ts
@@ -1,0 +1,28 @@
+import type bunyan from 'bunyan'
+import superagent from 'superagent'
+import TimeoutOptions from '../../types/TimeoutOptions'
+import config from '../../config'
+import { PrisonUser } from '../../types/HmppsUser'
+import { AllocationJobResponsibility } from '../../types/AllocationJobResponsibility'
+
+export default {
+  async getStaffAllocationPolicies(
+    user: PrisonUser,
+    timeoutOptions: TimeoutOptions,
+    log: bunyan | typeof console,
+  ): Promise<{ policies: AllocationJobResponsibility[] }> {
+    const result = await superagent
+      .get(
+        `${config.apis.allocationsApi.url}/prisons/${user.activeCaseLoadId}/staff/${user.userId}/job-classifications`,
+      )
+      .agent(this.agent)
+      .retry(2, (err, _res) => {
+        if (err) log.info(`Retry handler found API error with ${err.code} ${err.message}`)
+        return undefined // retry handler only for logging retries, not to influence retry logic
+      })
+      .auth(user.token, { type: 'bearer' })
+      .timeout(timeoutOptions)
+
+    return result.body
+  },
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import getPageComponents from './componentsService'
 import retrieveCaseLoadData from './caseLoadService'
+import retrieveAllocationJobResponsibilities from './allocationService'
 
 export default {
   /**
@@ -44,4 +45,25 @@ export default {
    * @param caseLoadOptions.timeoutOptions - timeout object for superagent. Defaults to 2500ms
    */
   retrieveCaseLoadData,
+
+  /**
+   * Ensures that:
+   * - `res.locals.user.allocationJobResponsibilities`
+   * is set for NOMIS users (or will propagate an error).  It will also attempt to cache in `req.session.allocationJobResponsibilities`
+   * (this is so that extra requests to Allocations API are not required for routes that do not need frontend components,
+   * such as image data, or if the frontend component API errors or is temporarily down).
+   *
+   * It will do the following in priority order, and will attempt the next if the previous fails:
+   *
+   *  * Use values from `res.feComponents.sharedData` if present (and cache in `req.session`)
+   *  * Use cached data from `req.session`
+   *  * Fetch data from Allocations API as a fallback and cache in `req.session`
+   *
+   * Expects res.locals.user to be set up inline with the hmpps-template-typescript project
+   *
+   * @param caseLoadOptions - config object for request
+   * @param caseLoadOptions.logger - pass in the bunyen logger if you want to use it. Falls back to console if not provided
+   * @param caseLoadOptions.timeoutOptions - timeout object for superagent. Defaults to 2500ms
+   */
+  retrieveAllocationJobResponsibilities,
 }

--- a/src/types/AllocationJobResponsibility.ts
+++ b/src/types/AllocationJobResponsibility.ts
@@ -1,0 +1,1 @@
+export type AllocationJobResponsibility = 'KEY_WORKER' | 'PERSONAL_OFFICER'

--- a/src/types/HeaderFooterSharedData.ts
+++ b/src/types/HeaderFooterSharedData.ts
@@ -1,10 +1,12 @@
 import CaseLoad from './CaseLoad'
 import Service from './Service'
+import { AllocationJobResponsibility } from './AllocationJobResponsibility'
 
 export default interface HeaderFooterSharedData {
   activeCaseLoad?: CaseLoad
   caseLoads: CaseLoad[]
   services: Service[]
+  allocationJobResponsibilities: AllocationJobResponsibility[]
 }
 
 export interface ComponentsSharedData {

--- a/src/types/HmppsUser.ts
+++ b/src/types/HmppsUser.ts
@@ -1,4 +1,5 @@
 import CaseLoad from './CaseLoad'
+import { AllocationJobResponsibility } from './AllocationJobResponsibility'
 
 export type AuthSource = 'nomis' | 'delius' | 'external' | 'azuread'
 
@@ -29,6 +30,7 @@ export interface PrisonUser extends BaseUser {
   caseLoads: CaseLoad[]
   activeCaseLoad?: CaseLoad
   activeCaseLoadId?: string
+  allocationJobResponsibilities?: AllocationJobResponsibility[]
 }
 
 /**


### PR DESCRIPTION
A recent change in [hmpps-micro-frontend-components](https://github.com/ministryofjustice/hmpps-micro-frontend-components) has added `allocationJobResponsibilities` (with type `('KEY_WORKER' | 'PERSONAL_OFFICER')[]`) to the shared data.

this PR adds a middleware for services that need to ensure that the user's allocation job responsibilities (ie, being a key worker or a personal officer) is available in res.locals.user.