### PR TITLE
CDPS-1620: Bring linting closer in line with HMPPS template

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,25 +1,3 @@
 import hmppsConfig from '@ministryofjustice/eslint-config-hmpps'
-import typescriptEslint from '@typescript-eslint/eslint-plugin'
 
-const defaultConfig = hmppsConfig({})
-
-defaultConfig.push({
-  plugins: {
-    '@typescript-eslint': typescriptEslint,
-  },
-  rules: {
-    'import/prefer-default-export': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
-    '@typescript-eslint/no-unused-vars': [
-      1,
-      {
-        argsIgnorePattern: 'res|next|^err|_',
-        ignoreRestSiblings: true,
-        caughtErrorsIgnorePattern: '^_',
-      },
-    ],
-    '@typescript-eslint/no-empty-object-type': [1, { allowInterfaces: 'always' }],
-  },
-})
-
-export default defaultConfig
+export default hmppsConfig({})

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "copy:assets": "rm -rf dist/assets && cp -r src/assets dist/assets",
     "security_audit": "npx audit-ci --config audit-ci.json",
     "precommit:secrets": "gitleaks git --pre-commit --redact --staged --verbose --config .gitleaks/config.toml",
-    "precommit:lint": "node_modules/.bin/lint-staged",
+    "precommit:lint": "lint-staged",
     "precommit:verify": "npm run typecheck && npm test"
   },
   "lint-staged": {
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/ministryofjustice/hmpps-connect-dps-components#readme",
   "devDependencies": {
-    "@ministryofjustice/eslint-config-hmpps": "^0.0.3",
+    "@ministryofjustice/eslint-config-hmpps": "^0.0.5",
     "@ministryofjustice/hmpps-auth-clients": "^0.0.1",
     "@ministryofjustice/hmpps-precommit-hooks": "^0.0.3",
     "@rollup/plugin-commonjs": "^28.0.6",
@@ -56,10 +56,7 @@
     "@types/jest": "^29.5.14",
     "@types/superagent": "^8.1.9",
     "@types/supertest": "^6.0.3",
-    "@typescript-eslint/eslint-plugin": "^8.38.0",
     "cheerio": "^1.0.0",
-    "eslint-import-resolver-typescript": "^4.4.4",
-    "eslint-plugin-no-only-tests": "^3.3.0",
     "express": "^4.21.2",
     "govuk-frontend": "^5.10.1",
     "jest": "^29.7.0",

--- a/src/@types/express/index.d.ts
+++ b/src/@types/express/index.d.ts
@@ -3,6 +3,8 @@ import HeaderFooterSharedData from '../../types/HeaderFooterSharedData'
 import { HmppsUser } from '../../types/HmppsUser'
 import { AllocationJobResponsibility } from '../../types/AllocationJobResponsibility'
 
+export default {}
+
 export declare global {
   namespace Express {
     interface SessionData {

--- a/src/componentsService.test.ts
+++ b/src/componentsService.test.ts
@@ -27,7 +27,7 @@ function setupApp(
   } = { user: prisonUser, includeSharedData: false, useFallbacksByDefault: false },
 ): express.Application {
   const app = express()
-  app.use((req, res, next) => {
+  app.use((_req, res, next) => {
     res.locals.user = user as HmppsUser
     next()
   })

--- a/src/componentsService.ts
+++ b/src/componentsService.ts
@@ -92,6 +92,7 @@ export default class ComponentsService {
         updateCsp(this.componentApiConfig.url, res)
 
         return next()
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
       } catch (_error) {
         this.logger.error('Failed to retrieve front end components, using fallbacks')
         useFallbacks(res.locals.user)

--- a/src/data/allocationsApi/allocationsApiClient.ts
+++ b/src/data/allocationsApi/allocationsApiClient.ts
@@ -9,7 +9,7 @@ export default class AllocationsApiClient extends RestClient {
   }
 
   async getStaffAllocationPolicies(user: PrisonUser): Promise<{ policies: AllocationJobResponsibility[] }> {
-    return this.get<{ policies: AllocationJobResponsibility[] }>(
+    return this.get(
       {
         path: `/prisons/${user.activeCaseLoadId}/staff/${user.userId}/job-classifications`,
       },

--- a/src/data/componentApi/componentApiClient.ts
+++ b/src/data/componentApi/componentApiClient.ts
@@ -14,8 +14,8 @@ export default class ComponentApiClient extends RestClient {
   }
 
   async getComponents<T extends AvailableComponent[]>(userToken: string): Promise<ComponentsApiResponse<T>> {
-    return this.get<ComponentsApiResponse<T>>({
-      path: `/components`,
+    return this.get({
+      path: '/components',
       query: 'component=header&component=footer',
       headers: { 'x-user-token': userToken },
     })

--- a/src/data/prisonApi/prisonApiClient.ts
+++ b/src/data/prisonApi/prisonApiClient.ts
@@ -8,7 +8,7 @@ export default class PrisonApiClient extends RestClient {
   }
 
   async getUserCaseLoads(userToken: string): Promise<CaseLoad[]> {
-    return this.get<CaseLoad[]>(
+    return this.get(
       {
         path: '/api/users/me/caseLoads',
         query: 'allCaseloads=true',


### PR DESCRIPTION
- removed eslint overrides to the shared HMPPS config – this is the cause of all changes to appease `eslint` and `tsc`
- no meaningful changes here, `any` type didn’t appear! 🎉 
- no difference in built javascript