### PR TITLE
CDPS-1906: Set CSP header from MFE-provided directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,22 @@ of routes. e.g. in `setUpAuthentication.ts` on the `/autherror` path:
 
 This will provide a stripped down header for if there is no user object on `res.locals`.
 
-### CSP
+### Content-Security-Policy
 
-The package updates the content-security-middleware to include references to the fe-components API. This package should
-be run after Helmet to prevent this being overwritten.
+The package updates the Content-Security-Policy response header (often set by [helmet middleware](https://www.npmjs.com/package/helmet))
+to permit cross-domain/origin access to the FE components API.
+This package should be run after helmet and other security middleware to prevent this being overwritten.
+
+There is a new parameter (which will become on by default in future) to use CSP directives as provided by the FE components API:
+
+```javascript
+app.use(getFrontendComponents({
+  logger,
+  componentApiConfig: config.apis.componentApi,
+  dpsUrl: config.serviceUrls.digitalPrison,
+  requestOptions: { updateContentSecurityPolicy: true }, // ← updateContentSecurityPolicy is false by default
+}))
+```
 
 ### Shared Data
 
@@ -191,6 +203,7 @@ This includes:
 - caseLoads (all caseloads the user has access to)
 - services (information on services the user has access to used for global navigation)
 - allocationJobResponsibilities (the allocation policy codes the user has the associated job responsibility for. Allocation policy codes are: `KEY_WORKER`, meaning the user is a key worker and `PERSONAL_OFFICER`, meaning the user is a personal officer.)
+- cspDirectives (Content-Security-Policy directives needed to use components from a different domain/origin)
 
 This can be useful e.g. for when your service needs access to activeCaseLoad information to prevent extra calls to the
 api and takes advantage of the caching that the micro frontend api does.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ministryofjustice/hmpps-connect-dps-components",
-  "version": "5.3.6",
+  "version": "5.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ministryofjustice/hmpps-connect-dps-components",
-      "version": "5.3.6",
+      "version": "5.4.0",
       "license": "MIT",
       "dependencies": {
         "@ministryofjustice/hmpps-rest-client": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/hmpps-connect-dps-components",
-  "version": "5.3.6",
+  "version": "5.4.0",
   "description": "A package to allow the inclusion of connect DPS micro frontend components within DPS applications",
   "main": "./dist/index.cjs",
   "module": "./dist/index.esm.js",

--- a/src/@types/express/index.d.ts
+++ b/src/@types/express/index.d.ts
@@ -1,7 +1,7 @@
-import CaseLoad from '../../types/CaseLoad'
-import HeaderFooterSharedData from '../../types/HeaderFooterSharedData'
-import { HmppsUser } from '../../types/HmppsUser'
-import { AllocationJobResponsibility } from '../../types/AllocationJobResponsibility'
+import type { AllocationJobResponsibility } from '../../types/AllocationJobResponsibility'
+import type CaseLoad from '../../types/CaseLoad'
+import type { HmppsUser } from '../../types/HmppsUser'
+import type SharedData from '../../types/SharedData'
 
 export default {}
 
@@ -19,7 +19,7 @@ export declare global {
       footer: string
       cssIncludes: string[]
       jsIncludes: string[]
-      sharedData?: HeaderFooterSharedData
+      sharedData?: SharedData
     }
 
     interface Request {

--- a/src/caseLoadService.ts
+++ b/src/caseLoadService.ts
@@ -32,7 +32,7 @@ export default class CaseLoadService {
           // Update cache with values from res.feComponents.sharedData if present
           if (res.locals.feComponents && res.locals.feComponents.sharedData) {
             req.session.caseLoads = res.locals.feComponents.sharedData.caseLoads
-            req.session.activeCaseLoad = res.locals.feComponents.sharedData.activeCaseLoad
+            req.session.activeCaseLoad = res.locals.feComponents.sharedData.activeCaseLoad ?? undefined
             req.session.activeCaseLoadId = res.locals.feComponents.sharedData.activeCaseLoad?.caseLoadId
           }
 

--- a/src/componentsService.test.ts
+++ b/src/componentsService.test.ts
@@ -19,7 +19,7 @@ const apiResponse: ComponentsApiResponse = {
     activeCaseLoad: null,
     services: [],
     allocationJobResponsibilities: [],
-    cspDirectives: {},
+    cspDirectives: { 'style-src': ['http://localhost'] },
   },
 }
 
@@ -28,10 +28,12 @@ function setupApp(
     user,
     includeSharedData = false,
     useFallbacksByDefault = false,
+    updateContentSecurityPolicy = false,
   }: {
     user?: HmppsUser
     includeSharedData?: boolean
     useFallbacksByDefault?: boolean
+    updateContentSecurityPolicy?: boolean
   } = { user: prisonUser },
 ): express.Application {
   const app = express()
@@ -57,8 +59,8 @@ function setupApp(
     logger: loggerMock,
     componentApiConfig: {
       url: 'http://fe-components',
-      timeout: { deadline: 2500, response: 2500 },
-      agent: { timeout: 2500 },
+      timeout: { deadline: 100, response: 100 },
+      agent: { timeout: 100 },
     },
     dpsUrl: 'http://dpsUrl',
   })
@@ -69,6 +71,7 @@ function setupApp(
       supportUrl: 'http://supportUrl',
       includeSharedData,
       useFallbacksByDefault,
+      updateContentSecurityPolicy,
     }),
   )
 
@@ -292,10 +295,44 @@ describe('getFrontendComponents', () => {
               activeCaseLoad: null,
               services: [],
               allocationJobResponsibilities: [],
-              cspDirectives: {},
+              cspDirectives: { 'style-src': ['http://localhost'] },
             },
           },
         })
     })
+  })
+
+  describe('Content-Security-Policy header', () => {
+    it.each([
+      { scenario: 'not be updated', updateContentSecurityPolicy: false },
+      { scenario: 'be updated', updateContentSecurityPolicy: true },
+    ])(
+      'should $scenario from MFE response if updateContentSecurityPolicy is $updateContentSecurityPolicy',
+      ({ updateContentSecurityPolicy }) => {
+        componentsApi.get('/components?component=header&component=footer').reply(200, apiResponse)
+
+        return request(setupApp({ user: prisonUser, updateContentSecurityPolicy }))
+          .get('/')
+          .expect('Content-Type', /json/)
+          .expect(200, {
+            feComponents: {
+              header: 'header',
+              footer: 'footer',
+              cssIncludes: ['header.css', 'footer.css'],
+              jsIncludes: ['header.js'],
+            },
+          })
+          .expect(res => {
+            expect(res.headers).toHaveProperty(
+              'content-security-policy',
+              updateContentSecurityPolicy
+                ? // from MFE response
+                  "default-src 'self';style-src 'self' http://localhost"
+                : // using built-in fallback
+                  "default-src 'self';script-src 'self' http://fe-components;style-src 'self' http://fe-components;img-src 'self' http://fe-components;font-src 'self' http://fe-components",
+            )
+          })
+      },
+    )
   })
 })

--- a/src/componentsService.test.ts
+++ b/src/componentsService.test.ts
@@ -4,15 +4,23 @@ import request from 'supertest'
 import nock from 'nock'
 import * as cheerio from 'cheerio'
 import Logger from 'bunyan'
+import type { ComponentsApiResponse } from './data/componentApi/componentApiClient'
 import ComponentsService from './componentsService'
 import { HmppsUser, PrisonUser, ProbationUser } from './types/HmppsUser'
 
 const prisonUser = { token: 'token', authSource: 'nomis', displayName: 'Edwin Shannon' } as PrisonUser
 const probationUser = { token: 'token', authSource: 'delius', displayName: 'Edwin Shannon' } as ProbationUser
-const apiResponse = {
+
+const apiResponse: ComponentsApiResponse = {
   header: { html: 'header', css: ['header.css'], javascript: ['header.js'] },
-  footer: { html: 'footer', css: ['footer.css'], javascript: ['footer.js'] },
-  meta: { shared: 'data' },
+  footer: { html: 'footer', css: ['footer.css'], javascript: [] },
+  meta: {
+    caseLoads: [],
+    activeCaseLoad: null,
+    services: [],
+    allocationJobResponsibilities: [],
+    cspDirectives: {},
+  },
 }
 
 function setupApp(
@@ -94,7 +102,7 @@ describe('getFrontendComponents', () => {
           header: 'header',
           footer: 'footer',
           cssIncludes: ['header.css', 'footer.css'],
-          jsIncludes: ['header.js', 'footer.js'],
+          jsIncludes: ['header.js'],
         },
       })
   })
@@ -278,8 +286,14 @@ describe('getFrontendComponents', () => {
             header: 'header',
             footer: 'footer',
             cssIncludes: ['header.css', 'footer.css'],
-            jsIncludes: ['header.js', 'footer.js'],
-            sharedData: { shared: 'data' },
+            jsIncludes: ['header.js'],
+            sharedData: {
+              caseLoads: [],
+              activeCaseLoad: null,
+              services: [],
+              allocationJobResponsibilities: [],
+              cspDirectives: {},
+            },
           },
         })
     })

--- a/src/componentsService.test.ts
+++ b/src/componentsService.test.ts
@@ -5,8 +5,8 @@ import nock from 'nock'
 import * as cheerio from 'cheerio'
 import Logger from 'bunyan'
 import type { ComponentsApiResponse } from './data/componentApi/componentApiClient'
+import type { HmppsUser, PrisonUser, ProbationUser } from './types/HmppsUser'
 import ComponentsService from './componentsService'
-import { HmppsUser, PrisonUser, ProbationUser } from './types/HmppsUser'
 
 const prisonUser = { token: 'token', authSource: 'nomis', displayName: 'Edwin Shannon' } as PrisonUser
 const probationUser = { token: 'token', authSource: 'delius', displayName: 'Edwin Shannon' } as ProbationUser
@@ -26,13 +26,13 @@ const apiResponse: ComponentsApiResponse = {
 function setupApp(
   {
     user,
-    includeSharedData,
-    useFallbacksByDefault,
+    includeSharedData = false,
+    useFallbacksByDefault = false,
   }: {
     user?: HmppsUser
     includeSharedData?: boolean
     useFallbacksByDefault?: boolean
-  } = { user: prisonUser, includeSharedData: false, useFallbacksByDefault: false },
+  } = { user: prisonUser },
 ): express.Application {
   const app = express()
   app.use((_req, res, next) => {
@@ -91,7 +91,7 @@ afterEach(() => {
 })
 
 describe('getFrontendComponents', () => {
-  it('should call fe components api and attach header and footer html with all css and js combined', async () => {
+  it('should call fe components api and attach header and footer html with all css and js combined', () => {
     componentsApi.get('/components?component=header&component=footer').reply(200, apiResponse)
 
     return request(setupApp())
@@ -109,7 +109,7 @@ describe('getFrontendComponents', () => {
 
   describe('fallbacks', () => {
     describe('when prison user', () => {
-      it('should provide a fallback header', async () => {
+      it('should provide a fallback header', () => {
         componentsApi
           .get('/components?component=header&component=footer')
           .reply(500)
@@ -132,7 +132,7 @@ describe('getFrontendComponents', () => {
           })
       })
 
-      it('should provide a fallback footer', async () => {
+      it('should provide a fallback footer', () => {
         componentsApi
           .get('/components?component=header&component=footer')
           .reply(500)
@@ -155,7 +155,7 @@ describe('getFrontendComponents', () => {
     })
 
     describe('when non-prison user', () => {
-      it('should provide a fallback header', async () => {
+      it('should provide a fallback header', () => {
         componentsApi
           .get('/components?component=header&component=footer')
           .reply(500)
@@ -178,7 +178,7 @@ describe('getFrontendComponents', () => {
           })
       })
 
-      it('should provide a fallback footer', async () => {
+      it('should provide a fallback footer', () => {
         componentsApi
           .get('/components?component=header&component=footer')
           .reply(500)
@@ -202,7 +202,7 @@ describe('getFrontendComponents', () => {
     })
 
     describe('when no user', () => {
-      it('should provide a fallback header', async () => {
+      it('should provide a fallback header', () => {
         return request(setupApp({ user: undefined }))
           .get('/')
           .expect('Content-Type', /json/)
@@ -219,7 +219,7 @@ describe('getFrontendComponents', () => {
           })
       })
 
-      it('should provide a fallback footer', async () => {
+      it('should provide a fallback footer', () => {
         return request(setupApp({ user: undefined }))
           .get('/')
           .expect('Content-Type', /json/)
@@ -236,7 +236,7 @@ describe('getFrontendComponents', () => {
     })
 
     describe('when configured to only use fallbacks', () => {
-      it('should provide a fallback header', async () => {
+      it('should provide a fallback header', () => {
         componentsApi.get('/components?component=header&component=footer').reply(200, apiResponse)
 
         return request(setupApp({ user: prisonUser, useFallbacksByDefault: true }))
@@ -255,7 +255,7 @@ describe('getFrontendComponents', () => {
           })
       })
 
-      it('should provide a fallback footer', async () => {
+      it('should provide a fallback footer', () => {
         componentsApi.get('/components?component=header&component=footer').reply(200, apiResponse)
 
         return request(setupApp({ user: prisonUser, useFallbacksByDefault: true }))
@@ -275,7 +275,7 @@ describe('getFrontendComponents', () => {
   })
 
   describe('shared data', () => {
-    it('should include shared data if includeSharedData is true', async () => {
+    it('should include shared data if includeSharedData is true', () => {
       componentsApi.get('/components?component=header&component=footer').reply(200, apiResponse)
 
       return request(setupApp({ user: prisonUser, includeSharedData: true }))

--- a/src/componentsService.ts
+++ b/src/componentsService.ts
@@ -14,7 +14,7 @@ export interface FrontendComponentRequestOptions {
   useFallbacksByDefault?: boolean
 }
 
-const defaultOptions: Partial<FrontendComponentRequestOptions> = {
+const defaultOptions: FrontendComponentRequestOptions = {
   includeSharedData: false,
   useFallbacksByDefault: false,
 }

--- a/src/componentsService.ts
+++ b/src/componentsService.ts
@@ -1,4 +1,4 @@
-import { type NextFunction, type Request, type Response, type RequestHandler } from 'express'
+import type { RequestHandler } from 'express'
 import { ApiConfig } from '@ministryofjustice/hmpps-rest-client'
 import ComponentApiClient from './data/componentApi/componentApiClient'
 import { getFallbackFooter, getFallbackHeader } from './utils/fallbacks'
@@ -12,11 +12,17 @@ export interface FrontendComponentRequestOptions {
   environmentName?: 'DEV' | 'PRE-PRODUCTION' | 'PRODUCTION'
   includeSharedData?: boolean
   useFallbacksByDefault?: boolean
+  /**
+   * Update Content-Security-Policy with directives returned by MFE components service
+   * (instead of predefined directives); false by default
+   */
+  updateContentSecurityPolicy?: boolean
 }
 
 const defaultOptions: FrontendComponentRequestOptions = {
   includeSharedData: false,
   useFallbacksByDefault: false,
+  updateContentSecurityPolicy: false,
 }
 
 export default class ComponentsService {
@@ -44,9 +50,9 @@ export default class ComponentsService {
       ...defaultOptions,
       ...(requestOptions || {}),
     }
-    const { includeSharedData, useFallbacksByDefault } = requestOptionsWithDefaults
+    const { includeSharedData, useFallbacksByDefault, updateContentSecurityPolicy } = requestOptionsWithDefaults
 
-    return async (_req: Request, res: Response, next: NextFunction) => {
+    return async (_req, res, next) => {
       const useFallbacks = (user: HmppsUser | null) => {
         res.locals.feComponents = {
           header: getFallbackHeader(user, this.dpsUrl, {
@@ -89,7 +95,11 @@ export default class ComponentsService {
           res.locals.feComponents.sharedData = meta
         }
 
-        updateCsp(this.componentApiConfig.url, res)
+        updateCsp({
+          directives: updateContentSecurityPolicy ? meta?.cspDirectives : undefined,
+          feComponentsUrl: this.componentApiConfig.url,
+          res,
+        })
 
         return next()
       } catch {

--- a/src/data/componentApi/componentApiClient.ts
+++ b/src/data/componentApi/componentApiClient.ts
@@ -4,7 +4,10 @@ import type Component from '../../types/Component'
 import type { ConnectDpsComponentLogger } from '../../types/ConnectDpsComponentLogger'
 import type SharedData from '../../types/SharedData'
 
-export type ComponentsApiResponse<T extends AvailableComponent[]> = Record<T[number], Component> & {
+export type ComponentsApiResponse<T extends AvailableComponent[] = AvailableComponent[]> = Record<
+  T[number],
+  Component
+> & {
   meta: SharedData
 }
 

--- a/src/data/componentApi/componentApiClient.ts
+++ b/src/data/componentApi/componentApiClient.ts
@@ -1,11 +1,11 @@
 import { ApiConfig, RestClient } from '@ministryofjustice/hmpps-rest-client'
-import AvailableComponent from '../../types/AvailableComponent'
-import Component from '../../types/Component'
-import { ConnectDpsComponentLogger } from '../../types/ConnectDpsComponentLogger'
-import { ComponentsSharedData } from '../../types/HeaderFooterSharedData'
+import type AvailableComponent from '../../types/AvailableComponent'
+import type Component from '../../types/Component'
+import type { ConnectDpsComponentLogger } from '../../types/ConnectDpsComponentLogger'
+import type SharedData from '../../types/SharedData'
 
 export type ComponentsApiResponse<T extends AvailableComponent[]> = Record<T[number], Component> & {
-  meta: ComponentsSharedData[T[number]] // TODO: rename 'meta' in the API response
+  meta: SharedData
 }
 
 export default class ComponentApiClient extends RestClient {

--- a/src/middleware/getFrontendComponents.ts
+++ b/src/middleware/getFrontendComponents.ts
@@ -1,7 +1,7 @@
 import { type RequestHandler } from 'express'
 import ComponentsService, { FrontendComponentRequestOptions } from '../componentsService'
 
-type MiddlewareOptions = {
+export type FrontendComponentsMiddlewareOptions = {
   requestOptions?: FrontendComponentRequestOptions
 } & Parameters<typeof ComponentsService.create>[0]
 
@@ -10,7 +10,7 @@ export default function getFrontendComponents({
   componentApiConfig,
   dpsUrl,
   requestOptions,
-}: MiddlewareOptions): RequestHandler {
+}: FrontendComponentsMiddlewareOptions): RequestHandler {
   const service = ComponentsService.create({ logger, componentApiConfig, dpsUrl })
   return service.getFrontendComponents(requestOptions)
 }

--- a/src/types/CspDirectives.ts
+++ b/src/types/CspDirectives.ts
@@ -1,0 +1,2 @@
+/** Map of CSP directive to necessary URL values */
+export type CspDirectives = Record<string, string[]>

--- a/src/types/HeaderFooterSharedData.ts
+++ b/src/types/HeaderFooterSharedData.ts
@@ -1,15 +1,13 @@
-import CaseLoad from './CaseLoad'
-import Service from './Service'
-import { AllocationJobResponsibility } from './AllocationJobResponsibility'
+import type SharedData from './SharedData'
 
-export default interface HeaderFooterSharedData {
-  activeCaseLoad?: CaseLoad
-  caseLoads: CaseLoad[]
-  services: Service[]
-  allocationJobResponsibilities: AllocationJobResponsibility[]
-}
+/** @deprecated: use `SharedData` directly */
+export type HeaderFooterSharedData = SharedData
 
+/** @deprecated: use `SharedData` directly */
+export default HeaderFooterSharedData
+
+/** @deprecated: use `SharedData` directly, the meta information is the same for all components */
 export interface ComponentsSharedData {
-  header: HeaderFooterSharedData
-  footer: HeaderFooterSharedData
+  header: SharedData
+  footer: SharedData
 }

--- a/src/types/SharedData.ts
+++ b/src/types/SharedData.ts
@@ -1,0 +1,10 @@
+import type CaseLoad from './CaseLoad'
+import type Service from './Service'
+import type { AllocationJobResponsibility } from './AllocationJobResponsibility'
+
+export default interface SharedData {
+  caseLoads: CaseLoad[]
+  activeCaseLoad: CaseLoad | null
+  services: Service[]
+  allocationJobResponsibilities: AllocationJobResponsibility[]
+}

--- a/src/types/SharedData.ts
+++ b/src/types/SharedData.ts
@@ -1,10 +1,20 @@
 import type CaseLoad from './CaseLoad'
 import type Service from './Service'
 import type { AllocationJobResponsibility } from './AllocationJobResponsibility'
+import type { CspDirectives } from './CspDirectives'
 
+/**
+ * Information about the current user and environment
+ */
 export default interface SharedData {
+  /** Caseloads available to prison user */
   caseLoads: CaseLoad[]
+  /** Currently active caseload for prison user */
   activeCaseLoad: CaseLoad | null
+  /** Services available to prison user */
   services: Service[]
+  /** Prison user allocated responsibilites */
   allocationJobResponsibilities: AllocationJobResponsibility[]
+  /** Content-Security-Policy directives needed to use components from a different domain/origin */
+  cspDirectives: CspDirectives
 }

--- a/src/utils/updateCsp.test.ts
+++ b/src/utils/updateCsp.test.ts
@@ -1,16 +1,15 @@
-import { type Response } from 'express'
+import type { Response } from 'express'
 import updateCsp from './updateCsp'
 
-describe('updateCsp', () => {
-  beforeEach(() => {
-    jest.resetAllMocks()
-  })
+const mockResponse = (cspHeader?: string): Response =>
+  ({
+    get: jest.fn(() => cspHeader),
+    set: jest.fn(),
+  }) as unknown as Response
 
+describe('updateCsp', () => {
   it('should add fe-components url to CSP directives', () => {
-    const res = {
-      get: jest.fn(() => "default-src 'self';script-src 'self';style-src 'self';img-src 'self';font-src 'self'"),
-      set: jest.fn(),
-    } as unknown as Response
+    const res = mockResponse("default-src 'self';script-src 'self';style-src 'self';img-src 'self';font-src 'self'")
 
     updateCsp('http://fe-components', res)
 
@@ -21,10 +20,7 @@ describe('updateCsp', () => {
   })
 
   it('should add required directives when CSP header is not set', () => {
-    const res = {
-      get: jest.fn(),
-      set: jest.fn(),
-    } as unknown as Response
+    const res = mockResponse()
 
     updateCsp('http://fe-components', res)
 
@@ -35,10 +31,7 @@ describe('updateCsp', () => {
   })
 
   it('should add required directives that are not present', () => {
-    const res = {
-      get: jest.fn(() => "default-src 'self'"),
-      set: jest.fn(),
-    } as unknown as Response
+    const res = mockResponse("default-src 'self'")
 
     updateCsp('http://fe-components', res)
 
@@ -49,13 +42,9 @@ describe('updateCsp', () => {
   })
 
   it('should not change any with existing reference to fe-components', () => {
-    const res = {
-      get: jest.fn(
-        () =>
-          "default-src 'self';script-src 'self' http://fe-components;style-src 'self' http://fe-components;img-src 'self' http://fe-components;font-src 'self'",
-      ),
-      set: jest.fn(),
-    } as unknown as Response
+    const res = mockResponse(
+      "default-src 'self';script-src 'self' http://fe-components;style-src 'self' http://fe-components;img-src 'self' http://fe-components;font-src 'self'",
+    )
 
     updateCsp('http://fe-components', res)
 
@@ -66,10 +55,7 @@ describe('updateCsp', () => {
   })
 
   it('should not confuse values that look like directive names', () => {
-    const res = {
-      get: jest.fn(() => "default-src 'self' http://script-src http://localhost"),
-      set: jest.fn(),
-    } as unknown as Response
+    const res = mockResponse("default-src 'self' http://script-src http://localhost")
 
     updateCsp('http://fe-components', res)
 

--- a/src/utils/updateCsp.test.ts
+++ b/src/utils/updateCsp.test.ts
@@ -8,9 +8,74 @@ const mockResponse = (cspHeader?: string): Response =>
   }) as unknown as Response
 
 describe('updateCsp', () => {
+  describe('using new options parameter with explicit directives', () => {
+    it('should do nothing if directives are provided but empty (fallbacks are not used)', () => {
+      const res = mockResponse("default-src 'self';script-src 'self' 'nonce-1234'")
+      updateCsp({ directives: {}, feComponentsUrl: 'http://fe-components', res })
+      expect(res.set).toHaveBeenCalledWith(
+        'content-security-policy',
+        // nothing changes
+        "default-src 'self';script-src 'self' 'nonce-1234'",
+      )
+    })
+
+    it('should update CSP header if given directives already existed', () => {
+      const res = mockResponse(
+        "default-src 'self';style-src 'self' http://localhost/assets;script-src 'self' 'nonce-1234';object-src 'none'",
+      )
+      updateCsp({
+        directives: {
+          'script-src': ['https://justice.gov.uk'],
+          'style-src': ['https://justice.gov.uk', 'https://gov.uk'],
+        },
+        feComponentsUrl: 'http://fe-components',
+        res,
+      })
+      expect(res.set).toHaveBeenCalledWith(
+        'content-security-policy',
+        // 1 url appended to script-src; 2 urls to style-src
+        "default-src 'self';style-src 'self' http://localhost/assets https://justice.gov.uk https://gov.uk;script-src 'self' 'nonce-1234' https://justice.gov.uk;object-src 'none'",
+      )
+    })
+
+    it('should update CSP header if directives did not exist', () => {
+      const res = mockResponse("default-src 'self';upgrade-insecure-requests")
+      updateCsp({
+        directives: {
+          'script-src': ['https://justice.gov.uk'],
+          'style-src': ['https://justice.gov.uk', 'https://gov.uk'],
+        },
+        feComponentsUrl: 'http://fe-components',
+        res,
+      })
+      expect(res.set).toHaveBeenCalledWith(
+        'content-security-policy',
+        // script-src created with 'self' and 1 url; style-src with 'self' and 2 urls
+        "default-src 'self';upgrade-insecure-requests;script-src 'self' https://justice.gov.uk;style-src 'self' https://justice.gov.uk https://gov.uk",
+      )
+    })
+
+    it('should create CSP header when none was set (including adding default-src)', () => {
+      const res = mockResponse()
+      updateCsp({
+        directives: {
+          'script-src': ['https://justice.gov.uk'],
+          'style-src': ['https://justice.gov.uk', 'https://gov.uk'],
+        },
+        feComponentsUrl: 'http://fe-components',
+        res,
+      })
+      expect(res.set).toHaveBeenCalledWith(
+        'content-security-policy',
+        // default-src created with 'self'; script-src created with 'self' and 1 url; style-src with 'self' and 2 urls
+        "default-src 'self';script-src 'self' https://justice.gov.uk;style-src 'self' https://justice.gov.uk https://gov.uk",
+      )
+    })
+  })
+
   describe.each([
     {
-      scenario: 'using new options parameter',
+      scenario: 'using new options parameter without explicit directives',
       test: (res: Response) => updateCsp({ feComponentsUrl: 'http://fe-components', res }),
     },
     {

--- a/src/utils/updateCsp.test.ts
+++ b/src/utils/updateCsp.test.ts
@@ -8,60 +8,71 @@ const mockResponse = (cspHeader?: string): Response =>
   }) as unknown as Response
 
 describe('updateCsp', () => {
-  it('should add fe-components url to CSP directives', () => {
-    const res = mockResponse("default-src 'self';script-src 'self';style-src 'self';img-src 'self';font-src 'self'")
+  describe.each([
+    {
+      scenario: 'using new options parameter',
+      test: (res: Response) => updateCsp({ feComponentsUrl: 'http://fe-components', res }),
+    },
+    {
+      scenario: 'using deprecated parameter syntax',
+      test: (res: Response) => updateCsp('http://fe-components', res),
+    },
+  ])('$scenario', ({ test }) => {
+    it('should add fe-components url to CSP directives', () => {
+      const res = mockResponse("default-src 'self';script-src 'self';style-src 'self';img-src 'self';font-src 'self'")
 
-    updateCsp('http://fe-components', res)
+      test(res)
 
-    expect(res.set).toHaveBeenCalledWith(
-      'content-security-policy',
-      "default-src 'self';script-src 'self' http://fe-components;style-src 'self' http://fe-components;img-src 'self' http://fe-components;font-src 'self' http://fe-components",
-    )
-  })
+      expect(res.set).toHaveBeenCalledWith(
+        'content-security-policy',
+        "default-src 'self';script-src 'self' http://fe-components;style-src 'self' http://fe-components;img-src 'self' http://fe-components;font-src 'self' http://fe-components",
+      )
+    })
 
-  it('should add required directives when CSP header is not set', () => {
-    const res = mockResponse()
+    it('should add required directives when CSP header is not set', () => {
+      const res = mockResponse()
 
-    updateCsp('http://fe-components', res)
+      test(res)
 
-    expect(res.set).toHaveBeenCalledWith(
-      'content-security-policy',
-      "default-src 'self';script-src 'self' http://fe-components;style-src 'self' http://fe-components;img-src 'self' http://fe-components;font-src 'self' http://fe-components",
-    )
-  })
+      expect(res.set).toHaveBeenCalledWith(
+        'content-security-policy',
+        "default-src 'self';script-src 'self' http://fe-components;style-src 'self' http://fe-components;img-src 'self' http://fe-components;font-src 'self' http://fe-components",
+      )
+    })
 
-  it('should add required directives that are not present', () => {
-    const res = mockResponse("default-src 'self'")
+    it('should add required directives that are not present', () => {
+      const res = mockResponse("default-src 'self'")
 
-    updateCsp('http://fe-components', res)
+      test(res)
 
-    expect(res.set).toHaveBeenCalledWith(
-      'content-security-policy',
-      "default-src 'self';script-src 'self' http://fe-components;style-src 'self' http://fe-components;img-src 'self' http://fe-components;font-src 'self' http://fe-components",
-    )
-  })
+      expect(res.set).toHaveBeenCalledWith(
+        'content-security-policy',
+        "default-src 'self';script-src 'self' http://fe-components;style-src 'self' http://fe-components;img-src 'self' http://fe-components;font-src 'self' http://fe-components",
+      )
+    })
 
-  it('should not change any with existing reference to fe-components', () => {
-    const res = mockResponse(
-      "default-src 'self';script-src 'self' http://fe-components;style-src 'self' http://fe-components;img-src 'self' http://fe-components;font-src 'self'",
-    )
+    it('should not change any with existing reference to fe-components', () => {
+      const res = mockResponse(
+        "default-src 'self';script-src 'self' http://fe-components;style-src 'self' http://fe-components;img-src 'self' http://fe-components;font-src 'self'",
+      )
 
-    updateCsp('http://fe-components', res)
+      test(res)
 
-    expect(res.set).toHaveBeenCalledWith(
-      'content-security-policy',
-      "default-src 'self';script-src 'self' http://fe-components;style-src 'self' http://fe-components;img-src 'self' http://fe-components;font-src 'self' http://fe-components",
-    )
-  })
+      expect(res.set).toHaveBeenCalledWith(
+        'content-security-policy',
+        "default-src 'self';script-src 'self' http://fe-components;style-src 'self' http://fe-components;img-src 'self' http://fe-components;font-src 'self' http://fe-components",
+      )
+    })
 
-  it('should not confuse values that look like directive names', () => {
-    const res = mockResponse("default-src 'self' http://script-src http://localhost")
+    it('should not confuse values that look like directive names', () => {
+      const res = mockResponse("default-src 'self' http://script-src http://localhost")
 
-    updateCsp('http://fe-components', res)
+      test(res)
 
-    expect(res.set).toHaveBeenCalledWith(
-      'content-security-policy',
-      "default-src 'self' http://script-src http://localhost;script-src 'self' http://fe-components;style-src 'self' http://fe-components;img-src 'self' http://fe-components;font-src 'self' http://fe-components",
-    )
+      expect(res.set).toHaveBeenCalledWith(
+        'content-security-policy',
+        "default-src 'self' http://script-src http://localhost;script-src 'self' http://fe-components;style-src 'self' http://fe-components;img-src 'self' http://fe-components;font-src 'self' http://fe-components",
+      )
+    })
   })
 })

--- a/src/utils/updateCsp.test.ts
+++ b/src/utils/updateCsp.test.ts
@@ -30,7 +30,7 @@ describe('updateCsp', () => {
 
     expect(res.set).toHaveBeenCalledWith(
       'content-security-policy',
-      "script-src 'self' http://fe-components;style-src 'self' http://fe-components;img-src 'self' http://fe-components;font-src 'self' http://fe-components",
+      "default-src 'self';script-src 'self' http://fe-components;style-src 'self' http://fe-components;img-src 'self' http://fe-components;font-src 'self' http://fe-components",
     )
   })
 

--- a/src/utils/updateCsp.ts
+++ b/src/utils/updateCsp.ts
@@ -1,22 +1,54 @@
-import { type Response } from 'express'
+import type { Response } from 'express'
+import type { CspDirectives } from '../types/CspDirectives'
 
+// TODO: add `default-src 'self'` if header was empty?
+
+/** Update Content-Security-Policy header in response to allow use of MFE components on another domain/origin */
 export default function updateCsp(feComponentsUrl: string, res: Response) {
-  const csp = res.get('content-security-policy')
-  const allDirectives = csp?.split(';') ?? []
-  const directivesToUpdate = ['script-src', 'style-src', 'img-src', 'font-src']
+  const cspHeader = res.get('content-security-policy')
+  const directives: CspDirectives = directivesFromHeader(cspHeader)
+  const requiredDirectives = fallbackDirectives(feComponentsUrl)
+  mergeDirectives(directives, requiredDirectives)
+  const newCspHeader = headerFromDirectives(directives)
+  res.set('content-security-policy', newCspHeader)
+}
 
-  const updatedCspDirectives = allDirectives.map(directive => {
-    // if directive is not in cspToUpdate or includes fe components url already return as is
-    if (directive.includes(feComponentsUrl) || !directivesToUpdate.some(p => directive.startsWith(`${p} `)))
-      return directive
+/** Minimal known requirements to use MFE components on another domain/origin */
+function fallbackDirectives(feComponentsUrl: string): CspDirectives {
+  return {
+    'script-src': [feComponentsUrl],
+    'style-src': [feComponentsUrl],
+    'img-src': [feComponentsUrl],
+    'font-src': [feComponentsUrl],
+  }
+}
 
-    // if directive is in cspToUpdate and does not have fe components url, add in
-    return `${directive} ${feComponentsUrl}`
+function directivesFromHeader(cspHeader: string | undefined): CspDirectives {
+  return Object.fromEntries(
+    (cspHeader?.split(';') ?? []).map(line => {
+      const [directive, ...values] = line.split(/\s+/)
+      return [directive, values]
+    }),
+  )
+}
+
+function headerFromDirectives(directives: CspDirectives): string {
+  return Object.entries(directives)
+    .map(([directive, values]) => (values.length > 0 ? `${directive} ${values.join(' ')}` : directive))
+    .join(';')
+}
+
+function mergeDirectives(directives: CspDirectives, overrides: Readonly<CspDirectives>): void {
+  Object.entries(overrides).forEach(([directive, values]) => {
+    if (directive in directives) {
+      values.forEach(value => {
+        if (!directives[directive].includes(value)) {
+          directives[directive].push(value)
+        }
+      })
+    } else {
+      // eslint-disable-next-line no-param-reassign
+      directives[directive] = ["'self'", ...values]
+    }
   })
-
-  const requiredAndNotPresent = directivesToUpdate
-    .filter(p => !updatedCspDirectives.find(directive => directive.startsWith(`${p} `)))
-    .map(p => `${p} 'self' ${feComponentsUrl}`)
-
-  res.set('content-security-policy', [...updatedCspDirectives, ...requiredAndNotPresent].join(';'))
 }

--- a/src/utils/updateCsp.ts
+++ b/src/utils/updateCsp.ts
@@ -1,8 +1,6 @@
 import type { Response } from 'express'
 import type { CspDirectives } from '../types/CspDirectives'
 
-// TODO: add `default-src 'self'` if header was empty?
-
 /** Update Content-Security-Policy header in response to allow use of MFE components on another domain/origin */
 export default function updateCsp(feComponentsUrl: string, res: Response) {
   const cspHeader = res.get('content-security-policy')
@@ -24,8 +22,9 @@ function fallbackDirectives(feComponentsUrl: string): CspDirectives {
 }
 
 function directivesFromHeader(cspHeader: string | undefined): CspDirectives {
+  const header = cspHeader || "default-src 'self'"
   return Object.fromEntries(
-    (cspHeader?.split(';') ?? []).map(line => {
+    (header.split(';') ?? []).map(line => {
       const [directive, ...values] = line.split(/\s+/)
       return [directive, values]
     }),

--- a/src/utils/updateCsp.ts
+++ b/src/utils/updateCsp.ts
@@ -26,13 +26,11 @@ export default function updateCsp(arg1: UpdateCspOptions | string, arg2?: Respon
     // eslint-disable-next-line no-param-reassign
     arg1 = { feComponentsUrl: arg1, res: arg2! }
   }
-  const { feComponentsUrl, res } = arg1
-
-  // TODO: directives parameter is ignored!
+  const { directives: providedDirectives, feComponentsUrl, res } = arg1
 
   const cspHeader = res.get('content-security-policy')
   const directives: CspDirectives = directivesFromHeader(cspHeader)
-  const requiredDirectives = fallbackDirectives(feComponentsUrl)
+  const requiredDirectives = providedDirectives ?? fallbackDirectives(feComponentsUrl)
   mergeDirectives(directives, requiredDirectives)
   const newCspHeader = headerFromDirectives(directives)
   res.set('content-security-policy', newCspHeader)

--- a/src/utils/updateCsp.ts
+++ b/src/utils/updateCsp.ts
@@ -1,8 +1,35 @@
 import type { Response } from 'express'
 import type { CspDirectives } from '../types/CspDirectives'
 
-/** Update Content-Security-Policy header in response to allow use of MFE components on another domain/origin */
-export default function updateCsp(feComponentsUrl: string, res: Response) {
+export interface UpdateCspOptions {
+  /** Content-Security-Policy directives to merge into response’s header */
+  directives?: CspDirectives
+  /** Base URL of MFE components service for fallback Content-Security-Policy directives */
+  feComponentsUrl: string
+  /** The express response whose Content-Security-Policy header should be updated */
+  res: Response
+}
+
+/**
+ * Update Content-Security-Policy header in response to allow use of MFE components on another domain/origin
+ * with given directives, falling back to predefined directives known to be required
+ */
+export default function updateCsp(options: UpdateCspOptions): void
+/**
+ * Update Content-Security-Policy header in response to allow use of MFE components on another domain/origin
+ * using predefined directives known to be required
+ * @deprecated provide options to `updateCsp` as a single object
+ */
+export default function updateCsp(feComponentsUrl: string, res: Response): void
+export default function updateCsp(arg1: UpdateCspOptions | string, arg2?: Response): void {
+  if (typeof arg1 === 'string') {
+    // eslint-disable-next-line no-param-reassign
+    arg1 = { feComponentsUrl: arg1, res: arg2! }
+  }
+  const { feComponentsUrl, res } = arg1
+
+  // TODO: directives parameter is ignored!
+
   const cspHeader = res.get('content-security-policy')
   const directives: CspDirectives = directivesFromHeader(cspHeader)
   const requiredDirectives = fallbackDirectives(feComponentsUrl)


### PR DESCRIPTION
depends on [mfe#542](https://github.com/ministryofjustice/hmpps-micro-frontend-components/pull/542)

previously, this library added the MFE domain (as passed into the `getFrontendComponents` middleware) to these directives: `script-src`, `style-src`, `img-src`, `font-src`

now, when present in MFE’s /components response and a flag was passed into `getFrontendComponents`, CSP directives to be added are taken from the `meta.cspDirectives` values. existing CSP directives in the express response are still preserved.


```javascript
app.use(getFrontendComponents({
  logger,
  componentApiConfig: config.apis.componentApi,
  dpsUrl: config.serviceUrls.digitalPrison,
  requestOptions: { updateContentSecurityPolicy: true }, // ← updateContentSecurityPolicy is false by default
}))
```