### PR TITLE
MAPB-702 Handle caseload changes signalled by DPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,60 @@ app.use(retrieveCaseLoadData({
 This middleware checks the `res.locals.user.authSource` so ensure that any mock auth data used in tests includes
 `auth_source: 'nomis'` in the response.
 
+### Reacting to a case load change
+
+When a user changes their active case load via the header switcher, DPS sends them back to the page they came from
+and appends `caseloadChanged=true` to the url:
+
+```
+https://your-service.hmpps.service.justice.gov.uk/prison/BFI?status=ACTIVE&caseloadChanged=true
+```
+
+Your service needs this because it cannot work the change out for itself. A request for another prison's page looks
+exactly the same whether the user just switched case load or deliberately followed a link to a prison they still
+have access to. Without the marker, a service whose urls contain a prison id re-renders the prison the user has
+just left, underneath a header showing the one they moved to.
+
+Two middlewares handle this. Order matters — the first has to run before the case load cache is populated, and the
+second after, so that it can act on the new case load:
+
+```javascript
+import {
+  getFrontendComponents,
+  invalidateCaseLoadCache,
+  retrieveCaseLoadData,
+  handleCaseloadChange,
+} from '@ministryofjustice/hmpps-connect-dps-components'
+
+app.get('*allPaths', getFrontendComponents({ logger, componentApiConfig: config.apis.frontendComponents, dpsUrl }))
+app.use(invalidateCaseLoadCache())
+app.use(retrieveCaseLoadData({ logger, prisonApiConfig: config.apis.prisonApi }))
+app.use(handleCaseloadChange({
+  rewriteUrl: (req, { activeCaseLoadId }) => `/prison/${activeCaseLoadId}`,
+}))
+```
+
+`invalidateCaseLoadCache` drops the cached case load data so it is loaded again for the new prison. **Add this even
+if you do not care about the url**: unless you pass `includeSharedData: true`, `retrieveCaseLoadData` fills the
+session once and never refreshes it, so without this your users see the old case load — and the old allocation job
+responsibilities, which are looked up per prison — for the rest of their session.
+
+`handleCaseloadChange` redirects to the corrected url and takes the marker back out of the address bar. Omit
+`rewriteUrl` if your urls do not contain a prison id and you only want the parameter stripped. The marker is always
+removed from whatever `rewriteUrl` returns, so a rewrite cannot cause a redirect loop.
+
+Requests without the marker are untouched by both, so normal traffic is unaffected.
+
+#### Never trust the parameter
+
+`caseloadChanged` is a hint, not a fact. Anyone can put it in a url. Never use it to decide which prison to show,
+and never let it skip an authorisation check — take the prison from `activeCaseLoadId` and let your existing checks
+run on the redirected request. The worst a hostile `?caseloadChanged=true` can then do is send the user to their own
+active case load.
+
+`CASELOAD_CHANGED_PARAM`, `hasCaseloadChanged(req)` and `withoutCaseloadChangedParam(url)` are also exported if you
+need to handle the marker yourself.
+
 ### Populating res.locals.user with the shared allocation job responsibilities
 
 This library also provides an optional middleware which populates:

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,12 @@
 export { default as getFrontendComponents } from './middleware/getFrontendComponents'
 export { default as retrieveCaseLoadData } from './middleware/retrieveCaseLoadData'
 export { default as retrieveAllocationJobResponsibilities } from './middleware/retrieveAllocationJobResponsibilities'
+export { default as invalidateCaseLoadCache } from './middleware/invalidateCaseLoadCache'
+export { default as handleCaseloadChange } from './middleware/handleCaseloadChange'
+export type { HandleCaseloadChangeOptions, CaseloadChangeContext } from './middleware/handleCaseloadChange'
+
+// Utils
+export { CASELOAD_CHANGED_PARAM, hasCaseloadChanged, withoutCaseloadChangedParam } from './utils/caseloadChange'
 
 // Services
 export { default as ComponentsService } from './componentsService'

--- a/src/middleware/handleCaseloadChange.test.ts
+++ b/src/middleware/handleCaseloadChange.test.ts
@@ -1,0 +1,83 @@
+import { Request, Response } from 'express'
+import handleCaseloadChange from './handleCaseloadChange'
+import { PrisonUser, ProbationUser } from '../types/HmppsUser'
+
+describe('handleCaseloadChange', () => {
+  const next = jest.fn()
+  const redirect = jest.fn()
+
+  const prisonUser = { authSource: 'nomis', activeCaseLoadId: 'CFI' } as PrisonUser
+
+  const responseFor = (user?: PrisonUser | ProbationUser) => ({ locals: { user }, redirect }) as unknown as Response
+
+  const requestFor = (originalUrl: string, query: Record<string, string> = {}) =>
+    ({ originalUrl, query }) as unknown as Request
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('does nothing without the marker', () => {
+    const req = requestFor('/prison/BFI?status=ACTIVE')
+
+    handleCaseloadChange()(req, responseFor(prisonUser), next)
+
+    expect(next).toHaveBeenCalled()
+    expect(redirect).not.toHaveBeenCalled()
+  })
+
+  it('strips the marker when no rewrite is supplied', () => {
+    const req = requestFor('/prison/BFI?status=ACTIVE&caseloadChanged=true', {
+      status: 'ACTIVE',
+      caseloadChanged: 'true',
+    })
+
+    handleCaseloadChange()(req, responseFor(prisonUser), next)
+
+    expect(redirect).toHaveBeenCalledWith('/prison/BFI?status=ACTIVE')
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('redirects to the rewritten url, given the new active case load', () => {
+    const req = requestFor('/prison/BFI?caseloadChanged=true', { caseloadChanged: 'true' })
+    const rewriteUrl = jest.fn((_req, { activeCaseLoadId }) => `/prison/${activeCaseLoadId}`)
+
+    handleCaseloadChange({ rewriteUrl })(req, responseFor(prisonUser), next)
+
+    expect(rewriteUrl).toHaveBeenCalledWith(req, { activeCaseLoadId: 'CFI' })
+    expect(redirect).toHaveBeenCalledWith('/prison/CFI')
+  })
+
+  it('falls back to the current url when the rewrite returns nothing', () => {
+    const req = requestFor('/somewhere?caseloadChanged=true', { caseloadChanged: 'true' })
+
+    handleCaseloadChange({ rewriteUrl: () => undefined })(req, responseFor(prisonUser), next)
+
+    expect(redirect).toHaveBeenCalledWith('/somewhere')
+  })
+
+  it('strips the marker from a rewritten url so it cannot redirect forever', () => {
+    const req = requestFor('/prison/BFI?caseloadChanged=true', { caseloadChanged: 'true' })
+
+    handleCaseloadChange({ rewriteUrl: () => '/prison/CFI?caseloadChanged=true' })(req, responseFor(prisonUser), next)
+
+    expect(redirect).toHaveBeenCalledWith('/prison/CFI')
+  })
+
+  it('passes no active case load for a non-prison user', () => {
+    const req = requestFor('/somewhere?caseloadChanged=true', { caseloadChanged: 'true' })
+    const rewriteUrl = jest.fn(() => undefined as string | undefined)
+
+    handleCaseloadChange({ rewriteUrl })(req, responseFor({ authSource: 'delius' } as ProbationUser), next)
+
+    expect(rewriteUrl).toHaveBeenCalledWith(req, { activeCaseLoadId: undefined })
+    expect(redirect).toHaveBeenCalledWith('/somewhere')
+  })
+
+  it('does not fail when there is no user', () => {
+    const req = requestFor('/somewhere?caseloadChanged=true', { caseloadChanged: 'true' })
+
+    expect(() => handleCaseloadChange()(req, responseFor(undefined), next)).not.toThrow()
+    expect(redirect).toHaveBeenCalledWith('/somewhere')
+  })
+})

--- a/src/middleware/handleCaseloadChange.ts
+++ b/src/middleware/handleCaseloadChange.ts
@@ -1,0 +1,55 @@
+import type { Request, RequestHandler } from 'express'
+import {
+  hasCaseloadChanged,
+  requestUrlWithoutCaseloadChangedParam,
+  withoutCaseloadChangedParam,
+} from '../utils/caseloadChange'
+
+export interface CaseloadChangeContext {
+  /** The user’s active case load after the change, or undefined if they are not a prison user */
+  activeCaseLoadId?: string
+}
+
+export interface HandleCaseloadChangeOptions {
+  /**
+   * Where to send the user now their active case load has changed. Supply this when your urls contain
+   * a prison id, e.g. `` (req, { activeCaseLoadId }) => `/prison/${activeCaseLoadId}` ``.
+   *
+   * Return nothing to fall back to the url the user is already on. The case load change marker is
+   * always stripped from whatever is returned.
+   */
+  rewriteUrl?: (req: Request, context: CaseloadChangeContext) => string | undefined | null
+}
+
+/**
+ * Sends the user on to a url that reflects the case load they have just switched to, and takes the
+ * marker back out of the address bar.
+ *
+ * A service cannot work out on its own that a switch has happened — a request for another prison’s
+ * page looks identical whether the user just switched or deliberately followed a link — so DPS tells
+ * it, and this middleware acts on that.
+ *
+ * Mount this *after* `retrieveCaseLoadData`, so that `activeCaseLoadId` describes the new prison:
+ *
+ * ```javascript
+ * app.use(retrieveCaseLoadData({ ... }))
+ * app.use(handleCaseloadChange({
+ *   rewriteUrl: (req, { activeCaseLoadId }) => `/prison/${activeCaseLoadId}`,
+ * }))
+ * ```
+ *
+ * Requests without the marker are untouched, so this is a no-op on all normal traffic.
+ */
+export default function handleCaseloadChange({ rewriteUrl }: HandleCaseloadChangeOptions = {}): RequestHandler {
+  return (req, res, next) => {
+    if (!hasCaseloadChanged(req)) return next()
+
+    const { user } = res.locals
+    const activeCaseLoadId = user?.authSource === 'nomis' ? user.activeCaseLoadId : undefined
+
+    const rewritten = rewriteUrl?.(req, { activeCaseLoadId })
+
+    // Strip the marker from the target too: a rewrite that kept it would redirect forever
+    return res.redirect(rewritten ? withoutCaseloadChangedParam(rewritten) : requestUrlWithoutCaseloadChangedParam(req))
+  }
+}

--- a/src/middleware/invalidateCaseLoadCache.test.ts
+++ b/src/middleware/invalidateCaseLoadCache.test.ts
@@ -1,0 +1,45 @@
+import { Request, Response } from 'express'
+import invalidateCaseLoadCache from './invalidateCaseLoadCache'
+
+describe('invalidateCaseLoadCache', () => {
+  const next = jest.fn()
+  const res = {} as Response
+
+  const cachedSession = () => ({
+    caseLoads: [{ caseLoadId: 'BFI' }],
+    activeCaseLoad: { caseLoadId: 'BFI' },
+    activeCaseLoadId: 'BFI',
+    allocationJobResponsibilities: ['KEY_WORKER'],
+    somethingElse: 'left alone',
+  })
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('clears the cached case load data when the case load has changed', () => {
+    const req = { query: { caseloadChanged: 'true' }, session: cachedSession() } as unknown as Request
+
+    invalidateCaseLoadCache()(req, res, next)
+
+    expect(req.session).toEqual({ somethingElse: 'left alone' })
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('leaves the cache alone without the marker', () => {
+    const session = cachedSession()
+    const req = { query: {}, session } as unknown as Request
+
+    invalidateCaseLoadCache()(req, res, next)
+
+    expect(req.session).toEqual(session)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('does not fail when there is no session', () => {
+    const req = { query: { caseloadChanged: 'true' } } as unknown as Request
+
+    expect(() => invalidateCaseLoadCache()(req, res, next)).not.toThrow()
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/src/middleware/invalidateCaseLoadCache.ts
+++ b/src/middleware/invalidateCaseLoadCache.ts
@@ -1,0 +1,31 @@
+import type { RequestHandler } from 'express'
+import { hasCaseloadChanged } from '../utils/caseloadChange'
+
+/**
+ * Drops the cached case load data when the user has just changed their active case load, so that
+ * `retrieveCaseLoadData` and `retrieveAllocationJobResponsibilities` load it again for the new prison.
+ *
+ * Without this, a service that does not request `includeSharedData` keeps serving the case load it
+ * cached the first time the user hit it, for the rest of their session. Allocation job responsibilities
+ * are looked up per prison, so they go stale in the same way.
+ *
+ * Mount this *before* `retrieveCaseLoadData`:
+ *
+ * ```javascript
+ * app.get('*allPaths', getFrontendComponents({ ... }))
+ * app.use(invalidateCaseLoadCache())
+ * app.use(retrieveCaseLoadData({ ... }))
+ * ```
+ */
+export default function invalidateCaseLoadCache(): RequestHandler {
+  return (req, _res, next) => {
+    if (hasCaseloadChanged(req) && req.session) {
+      delete req.session.caseLoads
+      delete req.session.activeCaseLoad
+      delete req.session.activeCaseLoadId
+      delete req.session.allocationJobResponsibilities
+    }
+
+    return next()
+  }
+}

--- a/src/types/public/middleware/index.ts
+++ b/src/types/public/middleware/index.ts
@@ -1,3 +1,14 @@
 export type { default as getFrontendComponents } from '../../../middleware/getFrontendComponents'
 export type { default as retrieveCaseLoadData } from '../../../middleware/retrieveCaseLoadData'
 export type { default as retrieveAllocationJobResponsibilities } from '../../../middleware/retrieveAllocationJobResponsibilities'
+export type { default as invalidateCaseLoadCache } from '../../../middleware/invalidateCaseLoadCache'
+export type {
+  default as handleCaseloadChange,
+  HandleCaseloadChangeOptions,
+  CaseloadChangeContext,
+} from '../../../middleware/handleCaseloadChange'
+export type {
+  CASELOAD_CHANGED_PARAM,
+  hasCaseloadChanged,
+  withoutCaseloadChangedParam,
+} from '../../../utils/caseloadChange'

--- a/src/utils/caseloadChange.test.ts
+++ b/src/utils/caseloadChange.test.ts
@@ -1,0 +1,54 @@
+import { Request } from 'express'
+import {
+  hasCaseloadChanged,
+  requestUrlWithoutCaseloadChangedParam,
+  withoutCaseloadChangedParam,
+} from './caseloadChange'
+
+describe('hasCaseloadChanged', () => {
+  it.each([
+    ['marker present', { caseloadChanged: 'true' }, true],
+    ['marker present but empty', { caseloadChanged: '' }, true],
+    ['other parameters only', { page: '2' }, false],
+    ['no parameters', {}, false],
+  ])('%s', (_scenario, query, expected) => {
+    expect(hasCaseloadChanged({ query } as unknown as Request)).toEqual(expected)
+  })
+
+  it('copes with a request that has no query', () => {
+    expect(hasCaseloadChanged({} as Request)).toEqual(false)
+  })
+})
+
+describe('withoutCaseloadChangedParam', () => {
+  it.each([
+    ['relative url, marker only', '/prison/BFI?caseloadChanged=true', '/prison/BFI'],
+    [
+      'relative url, keeps other parameters',
+      '/prison/BFI?status=ACTIVE&caseloadChanged=true',
+      '/prison/BFI?status=ACTIVE',
+    ],
+    ['relative url without the marker', '/prison/BFI?status=ACTIVE', '/prison/BFI?status=ACTIVE'],
+    ['relative url with no query', '/prison/BFI', '/prison/BFI'],
+    [
+      'absolute url stays absolute',
+      'https://example.service.justice.gov.uk/prison/BFI?caseloadChanged=true',
+      'https://example.service.justice.gov.uk/prison/BFI',
+    ],
+    ['repeated markers all removed', '/prison/BFI?caseloadChanged=true&caseloadChanged=true', '/prison/BFI'],
+  ])('%s', (_scenario, url, expected) => {
+    expect(withoutCaseloadChangedParam(url)).toEqual(expected)
+  })
+
+  it('preserves a fragment on a relative url', () => {
+    expect(withoutCaseloadChangedParam('/prison/BFI?caseloadChanged=true#results')).toEqual('/prison/BFI#results')
+  })
+})
+
+describe('requestUrlWithoutCaseloadChangedParam', () => {
+  it('strips the marker from the requested url', () => {
+    const req = { originalUrl: '/prison/BFI?status=ACTIVE&caseloadChanged=true' } as Request
+
+    expect(requestUrlWithoutCaseloadChangedParam(req)).toEqual('/prison/BFI?status=ACTIVE')
+  })
+})

--- a/src/utils/caseloadChange.ts
+++ b/src/utils/caseloadChange.ts
@@ -1,0 +1,34 @@
+import type { Request } from 'express'
+
+/**
+ * Query parameter that DPS appends to the return url after a user changes their active case load,
+ * to tell the service they came back to that its url may describe the prison they have just left.
+ *
+ * It is a hint only: anyone can put it in a url, so it must never be used to decide which prison to
+ * show. Use the user’s active case load for that.
+ */
+export const CASELOAD_CHANGED_PARAM = 'caseloadChanged'
+
+/** Base used to parse relative urls; never appears in the values returned to callers */
+const RELATIVE_URL_BASE = 'http://relative.invalid'
+
+/** Whether the request carries the case load change marker */
+export function hasCaseloadChanged(req: Request): boolean {
+  return Boolean(req.query && CASELOAD_CHANGED_PARAM in req.query)
+}
+
+/**
+ * The given url with the case load change marker removed, preserving all other query parameters.
+ * Relative urls stay relative. Used to make sure a redirect can never carry the marker onwards,
+ * which would redirect forever.
+ */
+export function withoutCaseloadChangedParam(url: string): string {
+  const parsed = new URL(url, RELATIVE_URL_BASE)
+  parsed.searchParams.delete(CASELOAD_CHANGED_PARAM)
+  return parsed.origin === RELATIVE_URL_BASE ? `${parsed.pathname}${parsed.search}${parsed.hash}` : parsed.href
+}
+
+/** The url this request was made to, with the case load change marker removed */
+export function requestUrlWithoutCaseloadChangedParam(req: Request): string {
+  return withoutCaseloadChangedParam(req.originalUrl)
+}


### PR DESCRIPTION
## What

Two new middlewares, plus a fix for a standing cache bug found on the way.

- `invalidateCaseLoadCache()` — clears cached caseload data when the user has just switched.
- `handleCaseloadChange({ rewriteUrl })` — redirects to a url reflecting the new prison and strips the marker.

Also exports `CASELOAD_CHANGED_PARAM`, `hasCaseloadChanged()` and `withoutCaseloadChangedParam()`.

## The standing bug — worth reviewing even if the rest is deferred

`retrieveCaseLoadData` refreshes `req.session.caseLoads` from `feComponents.sharedData` **only when that object is present**, and `includeSharedData` defaults to `false`. Otherwise the refetch is guarded behind `if (!req.session.caseLoads)`, so the session is filled once and never refreshed.

**Any service on the default shows a stale active caseload for the rest of the user's session after a switch.** `retrieveAllocationJobResponsibilities` has the identical pattern, and that data is looked up *per prison*, so key worker and personal officer status goes stale in a way that is straightforwardly wrong.

`invalidateCaseLoadCache()` fixes this, and is worth adopting whether or not a service has a prison in its urls.

Worth noting for a follow-up: `meta` is already fetched from the components API on every request. `includeSharedData` only controls whether it is *exposed*, so the data needed to stay fresh is already in hand and is being discarded. Defaulting that flag to `true` would make the cache self-healing, but that is a larger blast radius and I have deliberately not done it here.

## Why two middlewares rather than one

The ordering constraint is real and the failure mode is silent. The cache must be cleared *before* `retrieveCaseLoadData` repopulates it, and the redirect decided *after* — otherwise `activeCaseLoadId` still describes the prison the user has left, and the rewrite sends them straight back.

```javascript
app.get('*allPaths', getFrontendComponents({ ... }))
app.use(invalidateCaseLoadCache())     // must be before
app.use(retrieveCaseLoadData({ ... }))
app.use(handleCaseloadChange({ ... })) // must be after
```

Documented in the README with the required order.

## Design notes

- The marker is a **hint, never authoritative**. Anyone can put it in a url. The README states plainly that the prison must come from `activeCaseLoadId` and that existing authorisation must still run.
- The marker is always stripped from whatever `rewriteUrl` returns, so a rewrite cannot cause a redirect loop.
- Urls are built with `URL`/`URLSearchParams`; `req.query` is never mutated, since it is a getter in Express 5.
- Exports were added to `src/types/public/middleware/index.ts` as well as `src/index.ts` — the published `.d.ts` is generated from that surface, so without it these would have shipped untyped. Verified against the built `dist`.

## Context

Part of MAPB-699. DPS (MAPB-700) appends `caseloadChanged=true` to the return url after a switch.

## Testing

62 unit tests pass, 23 of them new. Lint and typecheck clean, build verified.